### PR TITLE
Updated writePreview example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async function writePreviewFromDraft(projectId = 'your-project-id') {
   // Create request payload
   const request = {
     parent: `projects/${projectId}`,
-    reviewSettings: {sandbox: {value: true}},
+    previewSettings: {sandbox: {value: true}},
     draft: {}
   };
   const [responsePromise, responseCallback] = getStreamResponsePromise();


### PR DESCRIPTION
when running current example, you would get a

```
(node:7851) UnhandledPromiseRejectionWarning: Error: 3 INVALID_ARGUMENT: Preview settings are missing.
    at Object.callErrorFromStatus (/Users/mish/Downloads/action-builder-test/node_modules/@grpc/grpc-js/build/src/call.js:31:26)
    at Object.onReceiveStatus (/Users/mish/Downloads/action-builder-test/node_modules/@grpc/grpc-js/build/src/client.js:247:52)
    at Object.onReceiveStatus (/Users/mish/Downloads/action-builder-test/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:336:141)
    at Object.onReceiveStatus (/Users/mish/Downloads/action-builder-test/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:299:181)
    at /Users/mish/Downloads/action-builder-test/node_modules/@grpc/grpc-js/build/src/call-stream.js:145:78
    at processTicksAndRejections (internal/process/task_queues.js:75:11)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:7851) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:7851) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```